### PR TITLE
Create ci-push-main.yml

### DIFF
--- a/.github/workflows/ci-push-main.yml
+++ b/.github/workflows/ci-push-main.yml
@@ -1,0 +1,17 @@
+name: CI - Push to main
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+    mergebot:
+      if: ${{ github.repository_owner == 'withstudiocms' && github.event_name == 'push' && github.event.commits[0].message != '[ci] lint' }}
+      uses: withstudiocms/automations/.github/workflows/mergebot.yml@main
+      secrets:
+        DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_MERGEBOT }}


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the CI process when changes are pushed to the `main` branch. The workflow includes a job that triggers a mergebot under specific conditions.

Key changes:

* Added a new GitHub Actions workflow configuration file `.github/workflows/ci-push-main.yml` to automate CI for pushes to the `main` branch.
* Configured the workflow to trigger on `workflow_dispatch` and `push` events for the `main` branch.
* Included permissions configuration to allow writing contents.
* Added a job named `mergebot` that runs only if the repository owner is `withstudiocms`, the event is a push, and the commit message is not `[ci] lint`.
* Configured the `mergebot` job to use a predefined workflow from `withstudiocms/automations` and set up a secret for the Discord webhook.
