### PR TITLE
Refactor PTAL embed creation and Add buttons to PTAL response to make it easier to access

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,5 +27,6 @@
     "drizzle-kit": "^0.28.1",
     "tsx": "^4.19.2",
     "typescript": "^5.6.3"
-  }
+  },
+  "packageManager": "pnpm@9.11.0+sha512.0a203ffaed5a3f63242cd064c8fb5892366c103e328079318f78062f24ea8c9d50bc6a47aa3567cabefd824d170e78fa2745ed1f16b132e16436146b7688f19b"
 }

--- a/src/commands/ptal.ts
+++ b/src/commands/ptal.ts
@@ -103,16 +103,9 @@ const handler = async (interaction: ChatInputCommandInteraction) => {
     return;
   }
 
-  const { embed, message, roleId } = await makePtalEmbed(pr, reviewList, description, pullRequestUrl, interaction.user, interaction.guild!.id);
+  const { newInteraction } = await makePtalEmbed(pr, reviewList, description, pullRequestUrl, interaction.user, interaction.guild!.id);
 
-  const reply = await interaction.reply({
-    content: message,
-    embeds: [embed],
-    fetchReply: true,
-    allowedMentions: {
-      roles: [roleId]
-    }
-  });
+  const reply = await interaction.reply(newInteraction);
 
   if (!reply) return;
 

--- a/src/utils/ptal/editPtalMessage.ts
+++ b/src/utils/ptal/editPtalMessage.ts
@@ -28,22 +28,18 @@ const editPtalMessage = async (data: typeof ptalTable.$inferSelect, client: Clie
 
   const originalMessage = await channel.messages.fetch(data.message);
 
-  const { embed, message, roleId } = await makePtalEmbed(
+  const pullRequestUrl = new URL(`https://github.com/${data.owner}/${data.repository}/pull/${data.pr}`)
+
+  const { edit } = await makePtalEmbed(
     pullReq.data,
     reviewList.data,
     data.description,
-    new URL(`https://github.com/${data.owner}/${data.repository}/pull/${data.pr}`),
+    pullRequestUrl,
     originalMessage.author,
     originalMessage.guild.id
   );
-
-  await originalMessage.edit({
-    content: message,
-    embeds: [embed],
-    allowedMentions: {
-      roles: [roleId]
-    }
-  });
+    
+  await originalMessage.edit(edit);
 
   if (pullReq.data.merged) {
     await db.delete(ptalTable).where(eq(ptalTable.id, data.id));

--- a/src/utils/ptal/makePtalEmbed.ts
+++ b/src/utils/ptal/makePtalEmbed.ts
@@ -5,6 +5,7 @@ import { guildsTable } from "@/db/schema";
 import { eq } from "drizzle-orm";
 import { parsePullRequest } from "./parsePullRequest";
 import { BRAND_COLOR } from "@/consts";
+import { client } from "@/index";
 
 /**
  * Returns the relevant emoji for a given status enum
@@ -98,21 +99,22 @@ const makePtalEmbed: MakePtalEmbed = async (
   });
   
   const viewOnGithub = new ButtonBuilder()
-    .setCustomId('ptal-github')
+    .setStyle(ButtonStyle.Link)
     .setLabel('See on GitHub')
-    .setURL(pullRequestUrl.href)
-    .setStyle(ButtonStyle.Primary)
-    .setEmoji('1329780197385441340');
+    .setURL(pullRequestUrl.href);
+  
+  if (client.emojis.resolve('1329780197385441340')) {
+    viewOnGithub.setEmoji('<:github:1329780197385441340>');
+  }
 
   const viewFiles = new ButtonBuilder()
-    .setCustomId('ptal-github-files')
+    .setStyle(ButtonStyle.Link)
     .setLabel('View Files')
-    .setURL(new URL('files', pullRequestUrl).href)
-    .setStyle(ButtonStyle.Primary)
-    .setEmoji(':open_file_folder:');
+    .setURL(new URL('files', pullRequestUrl).href);
   
-  const row = new ActionRowBuilder<ButtonBuilder>()
-    .addComponents(viewOnGithub, viewFiles);
+  const row = new ActionRowBuilder<ButtonBuilder>({
+    components: [viewOnGithub, viewFiles]
+  });
 
   return {
     newInteraction: {


### PR DESCRIPTION
This pull request includes several changes to the `ptal` command functionality in the `src/commands/ptal.ts`, `src/utils/ptal/editPtalMessage.ts`, and `src/utils/ptal/makePtalEmbed.ts` files. The main updates focus on refactoring the `makePtalEmbed` function to return more comprehensive interaction and edit options, as well as adding new buttons to the embed messages.

Refactoring and enhancements:

* [`src/commands/ptal.ts`](diffhunk://#diff-16811445af24c7dfa1718a2ad679d832e5d51b08ba867ed948bf0bde3fb8ec12L106-R108): Updated the `handler` function to use the new `newInteraction` property returned by `makePtalEmbed` for replying to interactions.
* [`src/utils/ptal/editPtalMessage.ts`](diffhunk://#diff-ff1f051a5166a4b1b012307e5bcb3d0b5fd3b09234ec8f9c3f430cdabc881e43L31-R42): Modified the `editPtalMessage` function to use the new `edit` property returned by `makePtalEmbed` for editing messages.
* [`src/utils/ptal/makePtalEmbed.ts`](diffhunk://#diff-9e8f41718ab4e37f5e76d5d9cbfa6d5e7d94a4a692b754b6692af1c3772406c5L2-R2): Added new imports for `ActionRowBuilder`, `ButtonBuilder`, `ButtonStyle`, `InteractionReplyOptions`, and `MessageEditOptions` from `discord.js`.

New functionality:

* [`src/utils/ptal/makePtalEmbed.ts`](diffhunk://#diff-9e8f41718ab4e37f5e76d5d9cbfa6d5e7d94a4a692b754b6692af1c3772406c5R22-R47): Defined a `MakePtalEmbed` type that includes `newInteraction` and `edit` properties, which are used to handle both new interactions and message edits.
* [`src/utils/ptal/makePtalEmbed.ts`](diffhunk://#diff-9e8f41718ab4e37f5e76d5d9cbfa6d5e7d94a4a692b754b6692af1c3772406c5L88-R135): Enhanced the `makePtalEmbed` function to include buttons for "See on GitHub" and "View Files" in the embed messages, improving user interaction with pull request notifications.