### PR TITLE
Make console log look less like an error

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -73,8 +73,8 @@ client.on('guildCreate', async (guild) => {
 });
 
 client.on('guildMemberAdd', async (member) => {
-  console.log("Member joined", member);
   if (member.user.bot || !member.user || !member.guild) return;
+  console.log("Member joined", member.user.username);
 
   const db = useDB();
   const data = await db.select().from(guildsTable).where(eq(guildsTable.id, member.guild.id));


### PR DESCRIPTION
Before:
```
2025-02-20T01:17:02.146327393Z Member joined GuildMember {
2025-02-20T01:17:02.146348588Z   guild: <ref *1> Guild {
2025-02-20T01:17:02.146352777Z     id: 'xxxxx',
2025-02-20T01:17:02.146355723Z     name: 'StudioCMS',
2025-02-20T01:17:02.146358598Z     icon: 'xxxxx',
2025-02-20T01:17:02.146361680Z     features: [
2025-02-20T01:17:02.146364578Z       'NEWS',
2025-02-20T01:17:02.146367387Z       'SOUNDBOARD',
2025-02-20T01:17:02.146370165Z       'COMMUNITY',
2025-02-20T01:17:02.146372907Z       'GUILD_ONBOARDING',
2025-02-20T01:17:02.146375709Z       'INVITE_SPLASH',
2025-02-20T01:17:02.146378492Z       'AUTO_MODERATION',
2025-02-20T01:17:02.146381293Z       'PREVIEW_ENABLED',
2025-02-20T01:17:02.146384122Z       'THREE_DAY_THREAD_ARCHIVE',
2025-02-20T01:17:02.146386968Z       'GUILD_ONBOARDING_EVER_ENABLED',
2025-02-20T01:17:02.146389769Z       'ANIMATED_ICON',
2025-02-20T01:17:02.146392532Z       'MEMBER_VERIFICATION_GATE_ENABLED',
2025-02-20T01:17:02.146395314Z       'GUILD_SERVER_GUIDE',
2025-02-20T01:17:02.146398082Z       'GUILD_ONBOARDING_HAS_PROMPTS',
2025-02-20T01:17:02.146400876Z       'ACTIVITY_FEED_DISABLED_BY_USER'
2025-02-20T01:17:02.146403644Z     ],
2025-02-20T01:17:02.146406414Z     commands: GuildApplicationCommandManager {
2025-02-20T01:17:02.146418184Z       permissions: [ApplicationCommandPermissionsManager],
2025-02-20T01:17:02.146420622Z       guild: [Circular *1]
2025-02-20T01:17:02.146422645Z     },
2025-02-20T01:17:02.146424654Z     members: GuildMemberManager { guild: [Circular *1] },
2025-02-20T01:17:02.146426694Z     channels: GuildChannelManager { guild: [Circular *1] },
2025-02-20T01:17:02.146428735Z     bans: GuildBanManager { guild: [Circular *1] },
2025-02-20T01:17:02.146430753Z     roles: RoleManager { guild: [Circular *1] },
2025-02-20T01:17:02.146433080Z     presences: PresenceManager {},
2025-02-20T01:17:02.146435213Z     voiceStates: VoiceStateManager { guild: [Circular *1] },
2025-02-20T01:17:02.146437314Z     stageInstances: StageInstanceManager { guild: [Circular *1] },
2025-02-20T01:17:02.146439379Z     invites: GuildInviteManager { guild: [Circular *1] },
2025-02-20T01:17:02.146441458Z     scheduledEvents: GuildScheduledEventManager { guild: [Circular *1] },
2025-02-20T01:17:02.146443576Z     autoModerationRules: AutoModerationRuleManager { guild: [Circular *1] },
2025-02-20T01:17:02.146445698Z     available: true,
2025-02-20T01:17:02.146447801Z     shardId: 0,
2025-02-20T01:17:02.146449935Z     splash: 'xxxxx',
2025-02-20T01:17:02.146452054Z     banner: null,
2025-02-20T01:17:02.146454270Z     description: 'Building the best, free, open-source tools with the community for all to use! Starting with StudioCMS',
2025-02-20T01:17:02.146456590Z     verificationLevel: 2,
2025-02-20T01:17:02.146458615Z     vanityURLCode: null,
2025-02-20T01:17:02.146460660Z     nsfwLevel: 0,
2025-02-20T01:17:02.146462704Z     premiumSubscriptionCount: 4,
2025-02-20T01:17:02.146464732Z     discoverySplash: null,
2025-02-20T01:17:02.146466750Z     memberCount: 70,
2025-02-20T01:17:02.146468818Z     large: true,
2025-02-20T01:17:02.146470905Z     premiumProgressBarEnabled: true,
2025-02-20T01:17:02.146472933Z     applicationId: null,
2025-02-20T01:17:02.146474962Z     afkTimeout: 300,
2025-02-20T01:17:02.146476964Z     afkChannelId: null,
2025-02-20T01:17:02.146478977Z     systemChannelId: 'xxxxx',
2025-02-20T01:17:02.146493572Z     premiumTier: 1,
2025-02-20T01:17:02.146495524Z     widgetEnabled: null,
2025-02-20T01:17:02.146497480Z     widgetChannelId: null,
2025-02-20T01:17:02.146499414Z     explicitContentFilter: 2,
2025-02-20T01:17:02.146501384Z     mfaLevel: 1,
2025-02-20T01:17:02.146503387Z     joinedTimestamp: 1732401328311,
2025-02-20T01:17:02.146505356Z     defaultMessageNotifications: 1,
2025-02-20T01:17:02.146508055Z     systemChannelFlags: SystemChannelFlagsBitField { bitfield: 12 },
2025-02-20T01:17:02.146513076Z     maximumMembers: 500000,
2025-02-20T01:17:02.146515156Z     maximumPresences: null,
2025-02-20T01:17:02.146517107Z     maxVideoChannelUsers: 25,
2025-02-20T01:17:02.146519058Z     maxStageVideoChannelUsers: 50,
2025-02-20T01:17:02.146521023Z     approximateMemberCount: null,
2025-02-20T01:17:02.146522980Z     approximatePresenceCount: null,
2025-02-20T01:17:02.146524900Z     vanityURLUses: null,
2025-02-20T01:17:02.146526888Z     rulesChannelId: 'xxxxx',
2025-02-20T01:17:02.146528868Z     publicUpdatesChannelId: 'xxxxx',
2025-02-20T01:17:02.146545638Z     preferredLocale: 'en-US',
2025-02-20T01:17:02.146563342Z     safetyAlertsChannelId: 'xxxxx',
2025-02-20T01:17:02.146565764Z     ownerId: 'xxxx',
2025-02-20T01:17:02.146567787Z     emojis: GuildEmojiManager { guild: [Circular *1] },
2025-02-20T01:17:02.146569805Z     stickers: GuildStickerManager { guild: [Circular *1] },
2025-02-20T01:17:02.146571836Z     incidentsData: null
2025-02-20T01:17:02.146573852Z   },
2025-02-20T01:17:02.146575823Z   joinedTimestamp: 1740014221797,
2025-02-20T01:17:02.146577901Z   premiumSinceTimestamp: null,
2025-02-20T01:17:02.146579897Z   nickname: null,
2025-02-20T01:17:02.146581897Z   pending: true,
2025-02-20T01:17:02.146583889Z   communicationDisabledUntilTimestamp: null,
2025-02-20T01:17:02.146585898Z   user: User {
2025-02-20T01:17:02.146587864Z     id: 'xxxx',
2025-02-20T01:17:02.146591153Z     bot: false,
2025-02-20T01:17:02.146593211Z     system: false,
2025-02-20T01:17:02.146595291Z     flags: UserFlagsBitField { bitfield: 0 },
2025-02-20T01:17:02.146597297Z     username: 'xxxx',
2025-02-20T01:17:02.146599430Z     globalName: 'xxxx',
2025-02-20T01:17:02.146601437Z     discriminator: '0',
2025-02-20T01:17:02.146603482Z     avatar: 'xxxxxxx',
2025-02-20T01:17:02.146605508Z     banner: undefined,
2025-02-20T01:17:02.146607522Z     accentColor: undefined,
2025-02-20T01:17:02.146609500Z     avatarDecoration: null,
2025-02-20T01:17:02.146612071Z     avatarDecorationData: null
2025-02-20T01:17:02.146614078Z   },
2025-02-20T01:17:02.146616045Z   avatar: null,
2025-02-20T01:17:02.146618192Z   banner: null,
2025-02-20T01:17:02.146620217Z   flags: GuildMemberFlagsBitField { bitfield: 8 }
2025-02-20T01:17:02.146622266Z }
```

After:
```
2025-02-20T01:17:02.146327393Z Member joined <username>
```
