### PR TITLE
Add member count api endpoint

### DIFF
--- a/src/server/webhooks.ts
+++ b/src/server/webhooks.ts
@@ -31,7 +31,7 @@ async function getMemberCount(serverId: string): Promise<number | null> {
     const guild = await client.guilds.fetch(serverId);
     return guild.memberCount ?? null;
   } catch (error) {
-    console.error(`Failed to fetch guild ${serverId}:`, error);
+    console.error("Failed to fetch guild %s:", serverId, error);
     return null;
   }
 }
@@ -76,8 +76,8 @@ const server = createServer(async (req: IncomingMessage, res: ServerResponse) =>
     return;
   }
 
-  if (req.url?.startsWith('/api/members/')) {
-    const serverId = req.url.match(SERVER_ID_REGEX)?.[1];
+  if (SERVER_ID_REGEX.test(req.url || '')) {
+    const serverId = req.url!.match(SERVER_ID_REGEX)?.[1];
 
     if (!serverId) {
       res.writeHead(400);

--- a/src/server/webhooks.ts
+++ b/src/server/webhooks.ts
@@ -24,10 +24,14 @@ webhooks.onAny((event) => {
   }
 });
 
-async function getMemberCount(serverId: string) {
+async function getMemberCount(serverId: string): Promise<number | null> {
+  if (!client.isReady()) return null;
+
   const guild = await client.guilds.fetch(serverId);
 
-  return guild.memberCount;
+  if (!guild) return null;
+
+  return guild.memberCount ?? null;
 }
 
 async function handlePullRequestChange(pr: PullRequestCallback) {
@@ -79,13 +83,19 @@ const server = createServer(async (req: IncomingMessage, res: ServerResponse) =>
       return;
     }
 
-    const membercount = await getMemberCount(serverId);
+    const memberCount = await getMemberCount(serverId);
+
+    if (memberCount === null) {
+      res.writeHead(500);
+      res.end();
+      return;
+    }
 
     res.writeHead(200, {
       'Content-Type': 'application/json',
     });
 
-    res.end(JSON.stringify({ members: membercount }));
+    res.end(JSON.stringify({ members: memberCount }));
   }
 
   res.writeHead(404);

--- a/src/server/webhooks.ts
+++ b/src/server/webhooks.ts
@@ -27,11 +27,13 @@ webhooks.onAny((event) => {
 async function getMemberCount(serverId: string): Promise<number | null> {
   if (!client.isReady()) return null;
 
-  const guild = await client.guilds.fetch(serverId);
-
-  if (!guild) return null;
-
-  return guild.memberCount ?? null;
+  try {
+    const guild = await client.guilds.fetch(serverId);
+    return guild.memberCount ?? null;
+  } catch (error) {
+    console.error(`Failed to fetch guild ${serverId}:`, error);
+    return null;
+  }
 }
 
 async function handlePullRequestChange(pr: PullRequestCallback) {


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

- Adds a new API endpoint that can be used to get the amount of members for a given server.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new API endpoint for retrieving member counts using a URL pattern.
	- Improved request validation and error handling, returning clear HTTP status codes (400 for invalid requests, 500 for errors, and 200 with the member count on success).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->