### PR TITLE
fix: Ensure PTAL URL is only built if protocol is included

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,5 +28,5 @@
     "tsx": "^4.19.2",
     "typescript": "^5.6.3"
   },
-  "packageManager": "pnpm@9.11.0+sha512.0a203ffaed5a3f63242cd064c8fb5892366c103e328079318f78062f24ea8c9d50bc6a47aa3567cabefd824d170e78fa2745ed1f16b132e16436146b7688f19b"
+  "packageManager": "pnpm@10.17.1"
 }

--- a/src/commands/ptal.ts
+++ b/src/commands/ptal.ts
@@ -57,6 +57,7 @@ const handler = async (interaction: ChatInputCommandInteraction) => {
       flags: [MessageFlags.Ephemeral],
       content: "GitHub URL must include protocol."
     });
+    return;
   }
 
   const pullRequestUrl = new URL(requestURLInput);

--- a/src/commands/ptal.ts
+++ b/src/commands/ptal.ts
@@ -49,8 +49,17 @@ const handler = async (interaction: ChatInputCommandInteraction) => {
 
   const octokit = await useGitHub();
 
+	const requestURLInput = interaction.options.get("github", true).value as string;
   const description = interaction.options.get("description", true).value as string;
-  const pullRequestUrl = new URL(interaction.options.get("github", true).value as string);
+
+  if (!requestURLInput.startsWith("http")) {
+    await interaction.reply({
+      flags: [MessageFlags.Ephemeral],
+      content: "GitHub URL must include protocol."
+    });
+  }
+
+  const pullRequestUrl = new URL(requestURLInput);
 
   if (pullRequestUrl.origin !== "https://github.com" || !pullRequestUrl.pathname.includes("/pull/")) {
     await interaction.reply({
@@ -87,7 +96,7 @@ const handler = async (interaction: ChatInputCommandInteraction) => {
         flags: [MessageFlags.Ephemeral],
         content: "Something went wrong while fetching the PR.",
       });
-  
+
       return;
     }
 
@@ -132,14 +141,14 @@ command
     option.setDescription("A link to the GitHub PR.");
     option.setMinLength(20); // Minimum of https://github.com/*
     option.setRequired(true);
-    
+
     return option;
   })
   .addStringOption((option) => {
     option.setName('description');
     option.setDescription('The message to send alongside the PTAL announcement. If none is given, the PR description is used.');
     option.setRequired(true);
-    
+
     return option;
   })
   .setDefaultMemberPermissions(PermissionFlagsBits.ModerateMembers);


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

## Description

- Fixes a crash that occurs when the PTAL URL didn't include the protocol.

## Testing

N/A
<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs
N/A
<!-- Could this affect a user’s behavior? We probably need to update docs! -->

<!--
Here’s what will happen next:

One of our maintainers will review your pull request as soon as possible. We strive to provide feedback within a day, but please understand that responses may occasionally take longer depending on the circumstance and our availability. If we request any changes, please feel free to ask for clarification or provide additional context. We appreciate your patience and contribution to the project.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Improved parsing of GitHub pull request URLs for the command to handle a wider range of inputs.

- Bug Fixes
  - Validation now requires a protocol (e.g., https://) and provides clearer ephemeral error messages for invalid PR links.

- Chores
  - Updated package manager to a newer pnpm release for improved stability and tooling compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->