### PR TITLE
fix: Update publish workflow to use Dokploy Compose

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,7 @@ name: Publish Docker image to GHCR
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   workflow_dispatch:
 
 permissions:
@@ -52,16 +52,16 @@ jobs:
           cache-to: type=inline
 
       - name: Verify pushed image
-        run: | 
+        run: |
           echo "Pushed: ghcr.io/${{ github.repository_owner }}/apollo:latest"
           echo "Pushed: ghcr.io/${{ github.repository_owner }}/apollo:${{ github.sha }}"
           echo "Pushed: ghcr.io/${{ github.repository_owner }}/apollo:${{ github.ref_name }}"
 
-      - name: Deploy Web App
-        run: |
-          curl -X 'POST' \
-            "${{ secrets.DOKPLOY_URL }}/api/application.deploy" \
-            -H 'accept: application/json' \
-            -H "x-api-key: ${{ secrets.DOKPLOY_AUTH_TOKEN }}" \
-            -H 'Content-Type: application/json' \
-            -d '{"applicationId": "${{ secrets.DOKPLOY_WEB_APPLICATION_ID }}"}'
+      - name: Deploy to Dokploy Compose
+        uses: withstudiocms/automations/.github/actions/deploy-dokploy-compose@b488fa91598547478e170a4742916293a91a4410 # main
+        id: deploy-dokploy
+        with:
+          api_url: ${{ secrets.DOKPLOY_API_URL }}
+          api_key: ${{ secrets.DOKPLOY_API_KEY }}
+          compose_id: ${{ secrets.DOKPLOY_COMPOSE_ID }}
+          image: ghcr.io/${{ github.repository_owner }}/apollo:${{ github.sha }}


### PR DESCRIPTION
This pull request updates the deployment step in the GitHub Actions workflow to use a standardized Dokploy Compose deployment action instead of a custom `curl` script. This change should make deployments more reliable and maintainable.

**Deployment process improvements:**

* Replaced the manual `curl` command for deploying the web app with the `withstudiocms/automations/.github/actions/deploy-dokploy-compose` GitHub Action, which uses explicit inputs for API URL, API key, compose ID, and image.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Migrated deployment process from curl-based approach to a new GitHub Action for enhanced automation and reliability.
  * Applied minor formatting updates to workflow configuration for consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->